### PR TITLE
build Railtrack and OBOR in parallel

### DIFF
--- a/Vagrantfile.vagrant-mesos-slave
+++ b/Vagrantfile.vagrant-mesos-slave
@@ -38,7 +38,6 @@ Vagrant.configure(2) do |config|
       machine.ssh.insert_key = false
 
       machine.vm.provider "virtualbox" do |vb|
-        vb.customize ["modifyvm", :id, "--cpus", "2"] 
         vb.memory = "4096" # to compile mesos we need > 2GB of RAM
         # https://github.com/hashicorp/otto/issues/423#issuecomment-186076403
         vb.linked_clone = true if Vagrant::VERSION =~ /^1.9/ 
@@ -51,7 +50,7 @@ Vagrant.configure(2) do |config|
         vb.customize [
           "storagectl", :id, 
           "--name", "IDE Controller",
-          "--hostiocache", "on"
+          "--hostiocache", "off"
         ]
       end
 

--- a/Vagrantfile.vagrant-mesos-zk-01
+++ b/Vagrantfile.vagrant-mesos-zk-01
@@ -38,7 +38,6 @@ Vagrant.configure(2) do |config|
       machine.ssh.insert_key = false
 
       machine.vm.provider "virtualbox" do |vb|
-        vb.customize ["modifyvm", :id, "--cpus", "2"] 
         vb.memory = "4096" # to compile mesos we need > 2GB of RAM
         # https://github.com/hashicorp/otto/issues/423#issuecomment-186076403
         vb.linked_clone = true if Vagrant::VERSION =~ /^1.9/ 
@@ -51,7 +50,7 @@ Vagrant.configure(2) do |config|
         vb.customize [
           "storagectl", :id, 
           "--name", "IDE Controller",
-          "--hostiocache", "on"
+          "--hostiocache", "off"
         ]
       end
 

--- a/Vagrantfile.vagrant-mesos-zk-02
+++ b/Vagrantfile.vagrant-mesos-zk-02
@@ -38,7 +38,6 @@ Vagrant.configure(2) do |config|
       machine.ssh.insert_key = false
 
       machine.vm.provider "virtualbox" do |vb|
-        vb.customize ["modifyvm", :id, "--cpus", "2"] 
         vb.memory = "4096" # to compile mesos we need > 2GB of RAM
         # https://github.com/hashicorp/otto/issues/423#issuecomment-186076403
         vb.linked_clone = true if Vagrant::VERSION =~ /^1.9/ 
@@ -51,7 +50,7 @@ Vagrant.configure(2) do |config|
         vb.customize [
           "storagectl", :id, 
           "--name", "IDE Controller",
-          "--hostiocache", "on"
+          "--hostiocache", "off"
         ]
       end
 

--- a/Vagrantfile.vagrant-mesos-zk-03
+++ b/Vagrantfile.vagrant-mesos-zk-03
@@ -38,7 +38,6 @@ Vagrant.configure(2) do |config|
       machine.ssh.insert_key = false
 
       machine.vm.provider "virtualbox" do |vb|
-        vb.customize ["modifyvm", :id, "--cpus", "2"] 
         vb.memory = "4096" # to compile mesos we need > 2GB of RAM
         # https://github.com/hashicorp/otto/issues/423#issuecomment-186076403
         vb.linked_clone = true if Vagrant::VERSION =~ /^1.9/ 
@@ -51,7 +50,7 @@ Vagrant.configure(2) do |config|
         vb.customize [
           "storagectl", :id, 
           "--name", "IDE Controller",
-          "--hostiocache", "on"
+          "--hostiocache", "off"
         ]
       end
 

--- a/Vagrantfile.vagrant-obor-box
+++ b/Vagrantfile.vagrant-obor-box
@@ -38,7 +38,6 @@ Vagrant.configure(2) do |config|
       machine.ssh.insert_key = false
 
       machine.vm.provider "virtualbox" do |vb|
-        vb.customize ["modifyvm", :id, "--cpus", "2"] 
         vb.memory = "4096" # to compile mesos we need > 2GB of RAM
         # https://github.com/hashicorp/otto/issues/423#issuecomment-186076403
         vb.linked_clone = true if Vagrant::VERSION =~ /^1.9/ 
@@ -51,7 +50,7 @@ Vagrant.configure(2) do |config|
         vb.customize [
           "storagectl", :id, 
           "--name", "IDE Controller",
-          "--hostiocache", "on"
+          "--hostiocache", "off"
         ]
       end
 

--- a/config/config.yaml.sample
+++ b/config/config.yaml.sample
@@ -52,9 +52,9 @@ common: &common
     # at boot, DNS is not yet available for our Tinc VPN 
     # as a work a workaround lets use IP addresses for now.
     # this assumes that our Masters have fixed IP addresses
-    192.168.56.101 core01
-    192.168.56.102 core02
-    192.168.56.103 core03
+    192.168.56.11 core01
+    192.168.56.12 core02
+    192.168.56.13 core03
 
   # Primary and Secondary Railtrack DNS servers
   mesos_dns_resolver1: '10.254.0.1' # DNS NS for the TINC network
@@ -90,7 +90,7 @@ common: &common
   
   # the first node for Railtrack:
   tinc_core_node01_tinc_ip_address: '10.254.0.1'
-  tinc_core_node01_fqdn: '192.168.56.101'
+  tinc_core_node01_fqdn: '192.168.56.11'
 
   # TINC public key for our first Railtrack Tinc node
   tinc_core_node01_public_key: |
@@ -110,7 +110,7 @@ common: &common
 
   # the second node for Railtrack:
   tinc_core_node02_tinc_ip_address: '10.254.0.2'
-  tinc_core_node02_fqdn: '192.168.56.102'
+  tinc_core_node02_fqdn: '192.168.56.12'
 
   tinc_core_node02_public_key: |
     -----BEGIN RSA PUBLIC KEY-----
@@ -129,7 +129,7 @@ common: &common
 
   # the third node for Railtrack:
   tinc_core_node03_tinc_ip_address: '10.254.0.3'
-  tinc_core_node03_fqdn: '192.168.56.103'
+  tinc_core_node03_fqdn: '192.168.56.13'
 
   tinc_core_node03_public_key: |
     -----BEGIN RSA PUBLIC KEY-----

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ pybookshelf
 docker-compose
 timeout_decorator
 six>=1.10.0
+pathos
+dill


### PR DESCRIPTION
This PR changes the vagrant CI process so that both Railtrack and OBOR are provisioned in parallel.
This shrinks build times as the Railtrack requirement is only needed by the time we reboot the OBOR instances.

With this change we reduce the build time to 47 minutes from 58minutes