### PR TITLE
drop sleep() and increase retry/timeout counts for our acceptance tests.

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -304,7 +304,7 @@ def test_mesos_masters():
 
 
 @task
-@retry(stop_max_attempt_number=3, wait_fixed=60000)
+@retry(stop_max_attempt_number=6, wait_fixed=90000)
 def run_testinfra_against_mesos_masters():
     local(
         "testinfra --connection=ssh --ssh-config=ssh.config "
@@ -330,7 +330,7 @@ def test_mesos_slaves():
 
 
 @task
-@retry(stop_max_attempt_number=3, wait_fixed=60000)
+@retry(stop_max_attempt_number=6, wait_fixed=90000)
 def run_testinfra_against_mesos_slaves():
     local(
         "testinfra --connection=ssh --ssh-config=ssh.config "
@@ -450,7 +450,7 @@ def jenkins_build():
         # reload after initial provision
         execute(vagrant_reload)
 
-        sleep(300)  # give it enough time for all services to start
+        sleep(180)
 
         # test all the things
         execute(vagrant_test_mesos_masters)

--- a/fabfile.py
+++ b/fabfile.py
@@ -55,6 +55,11 @@ def vagrant_halt_vm_with_retry(vm):
     local('VAGRANT_VAGRANTFILE=Vagrantfile.%s vagrant halt' % vm)
 
 
+@retry(stop_max_attempt_number=3, wait_fixed=10000)
+def vagrant_rsync_vm_with_retry(vm):
+    local('VAGRANT_VAGRANTFILE=Vagrantfile.%s vagrant rsync' % vm)
+
+
 @task
 def bake_obor_box():
     """ bakes a vagrant box for OBOR """
@@ -185,6 +190,7 @@ def spin_up_obor():
     ]:
         vagrant_up_vm_with_retry(vm)
         sleep(5)
+        vagrant_rsync_vm_with_retry(vm)
 
     log_green('spin_up_obor completed')
 


### PR DESCRIPTION
After the vagrant reload, our boxes take a few minutes to recover and start all required services. This is mostly as they're somehow dependent on each other. For example, everything depends on tinc-core. Zookeeper requires a tinc ip, Mesos masters/slaves require zookeeper to be up. Marathon requires mesos
master to be elected as well as a zookeeper connection.
There are monit checks that restart each service if they're not available, although those checks take a few minutes to act.

The changes in this commit, will move the sleep we usually have between a reload of the VMs and the run of the acceptance_tests to simply re-run the acceptance tests up to 'n' times with a longer wait period between them.
this generates more errors in the build.log but can save a couple of minutes vs a static sleep() block.