### PR TITLE
flaky: don't restart ZK nodes simultaneasly

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -220,23 +220,17 @@ def provision_obor():
 def vagrant_reload():
     log_green('running vagrant_reload')
 
-    pool = Pool()
-    results = []
-
-    def flow(vm):
-        vagrant_halt_vm_with_retry(vm)
-        vagrant_up_vm_with_retry(vm)
-
+    # reboot one VM at a time to maintain ZK cluster consistency
     for vm in [
         'vagrant-mesos-zk-01',
         'vagrant-mesos-zk-02',
         'vagrant-mesos-zk-03',
+        # reboot 01 one more time, as it seems to unblock marathon-lb
+        'vagrant-mesos-zk-01',
         'vagrant-mesos-slave'
     ]:
-        results.append(pool.apipe(flow, vm))
-
-    for stream in results:
-        stream.get()
+        vagrant_halt_vm_with_retry(vm)
+        vagrant_up_vm_with_retry(vm)
 
 
 @task


### PR DESCRIPTION
fixes some flakyness where marathon-lb doesn't come up correctly